### PR TITLE
feat: add loadConfig to read typed Script Properties

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,44 @@
+/**
+ * Script Properties を読み込んで検証済みの設定オブジェクトを返す
+ */
+export const loadConfig = () => {
+  const raw = PropertiesService.getScriptProperties().getProperties();
+  const getStringProperty = (
+    key: string,
+    options: {required: boolean; fallback?: string} = {required: false}
+  ): string => {
+    const value =
+      raw[key] === null || raw[key] === undefined
+        ? ""
+        : String(raw[key]).trim();
+    if (!value.length && options.required)
+      throw new Error(`Required property ${key} is missing.`);
+    if (!value.length && options.fallback !== undefined)
+      return options.fallback;
+    return value;
+  };
+
+  const getNumberProperty = (
+    key: string,
+    options: {required: boolean; fallback?: number} = {required: false}
+  ): number => {
+    const value =
+      raw[key] === null || raw[key] === undefined
+        ? undefined
+        : Number(raw[key]);
+    if (value === undefined && options.fallback !== undefined)
+      return options.fallback;
+    if (value === undefined || options.required)
+      throw new Error(`Required property ${key} is missing.`);
+    if (isNaN(value))
+      throw new Error(`Property ${key} is an invalid number: ${value}`);
+    return value;
+  };
+
+  const cfg = {
+    numberProperty: getNumberProperty("NUMBER_PROPERTY"),
+    stringProperty: getStringProperty("STRING_PROPERTY"),
+  };
+
+  return cfg;
+};


### PR DESCRIPTION
## 概要

Script Properties を型付きで読み込む `loadConfig` を `src/config.ts` に追加しました。

## 変更内容

- `getStringProperty` / `getNumberProperty` のヘルパーで、`required` と `fallback` をオプションで指定できるようにした
- 未設定・空文字・数値変換不可の場合は `Error` を投げる
- `loadConfig` は検証済みの設定オブジェクトを返す

## 補足

テンプレートのサンプルとして `NUMBER_PROPERTY` / `STRING_PROPERTY` を読む形にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)